### PR TITLE
Ensure scrollbars are hidden in Chrome

### DIFF
--- a/web/stylesheets/main.css
+++ b/web/stylesheets/main.css
@@ -332,3 +332,8 @@ and (max-device-width: 667px) {
     display: none;  
   }
 }
+
+::-webkit-scrollbar {
+  width: 0;
+  background: transparent;
+}


### PR DESCRIPTION
Fixing this:

![image](https://user-images.githubusercontent.com/2748216/27989561-e21b2d84-63ef-11e7-8cab-42d3d9d061e0.png)
